### PR TITLE
Allow NULL values in the field comment on table jenkins_build_changesets

### DIFF
--- a/db/migrate/005_create_jenkins_build_changesets.rb
+++ b/db/migrate/005_create_jenkins_build_changesets.rb
@@ -5,7 +5,7 @@ class CreateJenkinsBuildChangesets < ActiveRecord::Migration
       t.column :jenkins_build_id, :integer, :null => false
       t.column :repository_id,    :integer, :null => false
       t.column :revision,         :string,  :null => false
-      t.column :comment,          :text,    :null => false, :limit => 4294967295
+      t.column :comment,          :text,                    :limit => 4294967295
     end
   end
 


### PR DESCRIPTION
This PR aims to solve the issue detailed on issue #8 

This could be done using a new migration, however since the strategy in other PRs is editing the original migration file, I did the same.

In a running system, to apply this change without having to delete all tables is to run a script directly in the database:
(i.e. Mysql => ALTER TABLE jenkins_build_changesets CHANGE comment LONGTEXT NULL)

If you think this should be solved with a new migration, let me know, and I will send you a new PR.
