### PR TITLE
add missing translations to en and de

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -7,7 +7,8 @@ de:
   label_show_compact: Kompakte Anzeige
   label_wait_for_build_id: Warte auf Build Id
   label_test_connection: Verbindung testen
-  label_jenkins_version: Jenkins version
+  label_jenkins_version: Jenkins' Version
+  label_jenkins_jobs_count: Anzahl Aufgaben in Jenkins
 
   notice_settings_created: Einstellungen erfolgreich erstellt
   notice_settings_updated: Einstellungen erfolgreich aktualisiert
@@ -17,13 +18,14 @@ de:
   label_jobs_list_empty: Leer
   label_update_jobs_list: Aufgabenliste aktualisieren
   label_number_of_stored_builds: Anzahl Builds in Redmine
-  label_number_of_jenkins_builds: Anzahl Builds in in Jenkins
+  label_number_of_jenkins_builds: Anzahl Builds in Jenkins
+  label_number_of_builds_to_keep: Anzahl in Redmine zu haltender Builds
   label_last_changesets: Letzte Änderungen
   label_add_jenkins_job: Aufgaben hinzufügen
 
   error_http_error: "HTTP Error %{code}"
   error_invalid_url: URL ungültig
-  error_no_settings: "Keine Einstellungen gefungen, bitte <a href='%{url}'>überprüfen</a>"
+  error_no_settings: "Keine Einstellungen gefunden, bitte <a href='%{url}'>überprüfen</a>"
   error_jenkins_connection: Keine Verbindung mit Jenkins möglich
 
   ### JOBS
@@ -49,6 +51,7 @@ de:
 
   field_repository: Archiv
   field_job_name: Name
+  field_builds_to_keep: Anzahl zu behaltender Builds
 
   ### ACTIVITY
   label_build: Build

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
   label_wait_for_build_id: "Wait for build id"
   label_test_connection: Test connection
   label_jenkins_version: Jenkins version
+  label_jenkins_jobs_count: Number of jobs in Jenkins
 
   notice_settings_created: Settings created successfully
   notice_settings_updated: Settings updated successfully
@@ -18,6 +19,7 @@ en:
   label_update_jobs_list: Update Job list
   label_number_of_stored_builds: Number of stored builds in Redmine
   label_number_of_jenkins_builds: Number of builds in Jenkins
+  label_number_of_builds_to_keep: Number of builds to keep in Redmine
   label_last_changesets: Latest changes
   label_add_jenkins_job: Add a Job
 
@@ -49,6 +51,7 @@ en:
 
   field_repository: Repository
   field_job_name: Job name
+  field_builds_to_keep: Builds to keep
 
   ### ACTIVITY
   label_build: Build


### PR DESCRIPTION
Commit ae00feadc0f86f43ca8a0abf3fd1a8ec1485d276 introduced new functionality
but only the French locale file had the additional label texts.
