### PR TITLE
fix activity entry for atom feed

### DIFF
--- a/app/models/jenkins_build.rb
+++ b/app/models/jenkins_build.rb
@@ -57,7 +57,7 @@ class JenkinsBuild < ActiveRecord::Base
   end
 
 
-  def event_url
+  def event_url(options = {})
     url
   end
 


### PR DESCRIPTION
The event_url option in Redmine 2.6 supports optional parameters. Add this
to the plugin to allow the Atom activity feed to also include this plugin's
entries. Otherwise you get the following error when accessing the feed:

```
[ERROR] activities#index (ActionView::Template::Error) "wrong number of arguments (1 for 0)"
plugins/redmine_jenkins/app/models/jenkins_build.rb:60:in `event_url'
app/views/common/feed.atom.builder:13:in `block (3 levels) in _app_views_common_feed_atom_builder___4454006623991043638_28574860'
builder (3.0.4) lib/builder/xmlbase.rb:170:in `call'
[...]
```
