### PR TITLE
fix an issue that other plugins' patches are lost

### DIFF
--- a/lib/redmine_jenkins/patches/projects_helper_patch.rb
+++ b/lib/redmine_jenkins/patches/projects_helper_patch.rb
@@ -25,6 +25,7 @@ module RedmineJenkins
             :label   => :label_jenkins
           })
           tabs.select {|tab| User.current.allowed_to?(tab[:action], @project)}
+          tabs
         end
 
       end


### PR DESCRIPTION
First of all, thank you so much for your contribution to this great plugin. 

But I found an issue that other plugins' project setting tabs were lost after this plugin installation.
I think the function 'project_settings_tabs_with_redmine_jenkins' must return 'tabs'.
If it's right, please merge.